### PR TITLE
Ability to mockify local vars and fix matcher deallocation issue

### DIFF
--- a/Expecta+OCMock.h
+++ b/Expecta+OCMock.h
@@ -22,10 +22,7 @@
 
 #define mockify(OBJ) \
         try {} @finally {} \
-        _Pragma("clang diagnostic push") \
-        _Pragma("clang diagnostic ignored \"-Wshadow\"") \
         \
         typeof(OBJ) mockify_concat(OBJ, _original_) = OBJ; \
-        typeof(OBJ) OBJ = [OCMockObject partialMockForObject:mockify_concat(OBJ, _original_)]; \
+        OBJ = [OCMockObject partialMockForObject:mockify_concat(OBJ, _original_)]; \
         \
-        _Pragma("clang diagnostic pop")

--- a/Expecta+OCMock.m
+++ b/Expecta+OCMock.m
@@ -6,11 +6,11 @@
 #import <XCTest/XCTest.h>
 
 @interface ORExpectaOCMockMatcher : NSObject <EXPMatcher>
-- (instancetype)initWithExpectation:(EXPExpect *)expectation object:(id)object;
+- (instancetype)initWithExpectation:(EXPExpect *)expectation;
 @end
 
 @interface ORExpectaOCMockMatcher()
-@property (nonatomic, strong) EXPExpect *expectation;
+@property (nonatomic, weak) EXPExpect *expectation;
 @property (nonatomic, assign) SEL selector;
 @property (nonatomic, copy) NSArray *arguments;
 @property (nonatomic, strong) id returning;
@@ -21,7 +21,7 @@
 
 @implementation ORExpectaOCMockMatcher
 
-- (instancetype)initWithExpectation:(EXPExpect *)expectation object:(id)object
+- (instancetype)initWithExpectation:(EXPExpect *)expectation
 {
     self = [super init];
     if (!self) { return nil; }
@@ -123,11 +123,8 @@
 - (EXPExpect *(^) (SEL)) receive {
     __block id actual = self.actual;
 
-    ORExpectaOCMockMatcher *matcher = [[ORExpectaOCMockMatcher alloc] initWithExpectation:self object:actual];
-    objc_setAssociatedObject(self, @selector(_expectaOCMatcher), matcher, OBJC_ASSOCIATION_ASSIGN);
-
-    // This means we don't dealloc correctly, but it is normally set
-    // [[[NSThread currentThread] threadDictionary] setObject:matcher forKey:@"EXP_currentMatcher"];
+    ORExpectaOCMockMatcher *matcher = [[ORExpectaOCMockMatcher alloc] initWithExpectation:self];
+    objc_setAssociatedObject(self, @selector(_expectaOCMatcher), matcher, OBJC_ASSOCIATION_RETAIN);
 
     EXPExpect *(^matcherBlock) (SEL selector) = [^ (SEL selector) {
         matcher.selector = selector;


### PR DESCRIPTION
Fix for: https://github.com/dblock/ocmock-expecta/issues/4

Also I'm not sure what was idea behind shadow variable, I believe that the same one should be used.
