### PR TITLE
Change name of pod in README to the correct one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ it(@"checks for an argument to the method", ^{
 ### Get it
 
 ```
-pod "Expecta-OCMock", "~> 2"
+pod "Expecta+OCMock", "~> 2"
 ```
 
 For OCMock 2 support, 
 
 ```
-pod "Expecta-OCMock", "~> 1"
+pod "Expecta+OCMock", "~> 1"
 ```
 
 ### License


### PR DESCRIPTION
`pod search Expecta-OCMock` wasn't returning anything so I fixed the Podfile specification in the README.

See: https://cocoapods.org/?q=Expecta-OCMock
And: https://cocoapods.org/?q=Expecta%2BOCMock
