### PR TITLE
Fix README.md CocoaPods integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ it(@"checks for an argument to the method", ^{
 ### Get it
 
 ```
-pod "Expecta+OCMock", "~> 2"
+pod "Expecta+OCMock", "~> 2.0"
 ```
 
 For OCMock 2 support, 
 
 ```
-pod "Expecta+OCMock", "~> 1"
+pod "Expecta+OCMock", "~> 1.0"
 ```
 
 ### License


### PR DESCRIPTION
From [CocoaPods documentation](https://guides.cocoapods.org/using/the-podfile.html):
"'~> 0' Version 0 and higher, this is basically the same as not having it."
